### PR TITLE
simple.security.properties 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Simple Spring Security depends on [Model Mapper](https://github.com/modelmapper/
 <dependency>
   <groupId>com.github.ckpoint</groupId>
   <artifactId>simple-spring-security</artifactId>
-  <version>0.0.1</version>
+  <version>0.0.2</version>
 </dependency>
 
 ```
 #### 2. GRADLE
 ```gradle
-  compile group: 'com.github.ckpoint', name: 'simple-spring-security', version: '0.0.1'
+  compile group: 'com.github.ckpoint', name: 'simple-spring-security', version: '0.0.2'
 ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Simple Spring Security depends on [Model Mapper](https://github.com/modelmapper/
 - [ 3. Change Password Encoder (Optional)](#change-password-encoder)
 - [ 4. Encode password ](#encode-password)
 - [ 5. Add Login Controller ](#add-login-controller)
+- [ 6. Properties ](#properties)
 
 ## Add Simple UserDetails
 
@@ -167,3 +168,13 @@ public class AccountController {
 ```
 
 #### !! If the parameter of the controller extends SimpleUserDetails, it automatically passes the information stored in the session to the controller parameter.
+
+
+## Properties
+
+#### simple.security.csrf.enable : csrf enable setting - default value true
+#### simple.security.cors.enable : cors enable setting - default value false
+#### simple.security.cors.url : cors mapping pattern - default value /**
+#### simple.security.cors.origins : cors origins setting - default value *
+#### simple.security.cors.methods : cors methods setting - default value *
+#### simple.security.cors.headers : cors headers setting - default value *

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.ckpoint</groupId>
     <artifactId>simple-spring-security</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <packaging>jar</packaging>
 
     <name>SimpleSpringSecurity</name>

--- a/lib/src/main/java/hsim/simple/security/account/SimpleUserDetails.java
+++ b/lib/src/main/java/hsim/simple/security/account/SimpleUserDetails.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
  * The type Simple user details.
  */
 @Data
-public abstract class SimpleUserDetails implements UserDetails {
+public class SimpleUserDetails implements UserDetails {
 
     private static String DEFAULT_NONE_ROLE = "NONE";
 

--- a/lib/src/main/java/hsim/simple/security/account/SimpleUserDetails.java
+++ b/lib/src/main/java/hsim/simple/security/account/SimpleUserDetails.java
@@ -1,11 +1,13 @@
 package hsim.simple.security.account;
 
 import hsim.simple.security.util.ObjectGenerator;
+import lombok.Data;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -14,9 +16,15 @@ import java.util.stream.Collectors;
 /**
  * The type Simple user details.
  */
+@Data
 public abstract class SimpleUserDetails implements UserDetails {
 
     private static String DEFAULT_NONE_ROLE = "NONE";
+
+    private String username;
+    private String password;
+    private String role;
+    private List<String> roles;
 
     /**
      * Update from obj simple user details.
@@ -60,23 +68,10 @@ public abstract class SimpleUserDetails implements UserDetails {
         return true;
     }
 
-    @Override
-    public abstract String getPassword();
-
-    @Override
-    public abstract String getUsername();
-
-    /**
-     * Gets role.
-     *
-     * @return the role
-     */
-    protected abstract String getRole();
-
-    /**
-     * Gets roles.
-     *
-     * @return the roles
-     */
-    protected abstract List<String> getRoles();
+    public void addRole(String role) {
+        if (this.roles == null) {
+            this.roles = new ArrayList<>();
+        }
+        this.roles.add(role);
+    }
 }

--- a/lib/src/main/java/hsim/simple/security/config/SimpleSecurityProperties.java
+++ b/lib/src/main/java/hsim/simple/security/config/SimpleSecurityProperties.java
@@ -1,0 +1,27 @@
+package hsim.simple.security.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+public class SimpleSecurityProperties {
+
+    @Value("${simple.security.cors.enable:false}")
+    private boolean enableCors;
+
+    @Value("${simple.security.csrf.enable:true}")
+    private boolean enableCsrf;
+
+    @Value("${simple.security.cors.url:/**}")
+    private String corsMappingUrl;
+
+    @Value("${simple.security.cors.origins:*}")
+    private String corsAllowedOrigins;
+
+    @Value("${simple.security.cors.methods:*}")
+    private String corsAllowedMethods;
+
+    @Value("${simple.security.cors.headers:*}")
+    private String corsAllowedHeaders;
+}

--- a/lib/src/main/java/hsim/simple/security/service/SimpleSecurityService.java
+++ b/lib/src/main/java/hsim/simple/security/service/SimpleSecurityService.java
@@ -1,6 +1,7 @@
 package hsim.simple.security.service;
 
 import hsim.simple.security.account.SimpleUserDetails;
+import hsim.simple.security.config.SimpleSecurityProperties;
 import hsim.simple.security.resolver.SimpleUserDetailsResolver;
 import hsim.simple.security.spring.config.SecurityAdapterConfig;
 import hsim.simple.security.util.ObjectGenerator;
@@ -32,6 +33,7 @@ public abstract class SimpleSecurityService extends SecurityContextHolder {
     private SecurityAdapterConfig securityAdapterConfig;
     private PasswordEncoder passwordEncoder;
     private AuthenticationManager authenticationManager;
+    private SimpleSecurityProperties properties;
 
     /**
      * Login simple user details.
@@ -84,6 +86,12 @@ public abstract class SimpleSecurityService extends SecurityContextHolder {
         return ObjectGenerator.enableFieldModelMapper().map(principal, type);
     }
 
+    @Bean
+    public SimpleSecurityProperties simpleSecurityProperties() {
+        this.properties = new SimpleSecurityProperties();
+        return this.properties;
+    }
+
 
     /**
      * User detail service simple user detail service.
@@ -114,7 +122,7 @@ public abstract class SimpleSecurityService extends SecurityContextHolder {
      */
     @Bean
     public SecurityAdapterConfig springSecurityConfig() {
-        this.securityAdapterConfig = new SecurityAdapterConfig(this);
+        this.securityAdapterConfig = new SecurityAdapterConfig(this, this.properties);
         return this.securityAdapterConfig;
     }
 
@@ -170,8 +178,10 @@ public abstract class SimpleSecurityService extends SecurityContextHolder {
      * @param registry the registry
      */
     public void addCorsMappings(CorsRegistry registry) {
-        if (isUseCors()) {
-            registry.addMapping("/**").allowedOrigins("*").allowedMethods("*").allowedHeaders("*");
+
+        if (this.properties.isEnableCors()) {
+            registry.addMapping(this.properties.getCorsMappingUrl()).allowedOrigins(this.properties.getCorsAllowedOrigins())
+                    .allowedMethods(this.properties.getCorsAllowedMethods()).allowedHeaders(this.properties.getCorsAllowedHeaders());
         }
     }
 
@@ -278,20 +288,6 @@ public abstract class SimpleSecurityService extends SecurityContextHolder {
      */
     public void extendHandlerExceptionResolvers(List<HandlerExceptionResolver> resolvers) {
     }
-
-    /**
-     * Is use csrf boolean.
-     *
-     * @return the boolean
-     */
-    public abstract boolean isUseCsrf();
-
-    /**
-     * Is use cors boolean.
-     *
-     * @return the boolean
-     */
-    public abstract boolean isUseCors();
 
     /**
      * Create password encoder password encoder.

--- a/lib/src/main/java/hsim/simple/security/spring/config/SecurityAdapterConfig.java
+++ b/lib/src/main/java/hsim/simple/security/spring/config/SecurityAdapterConfig.java
@@ -1,5 +1,6 @@
 package hsim.simple.security.spring.config;
 
+import hsim.simple.security.config.SimpleSecurityProperties;
 import hsim.simple.security.service.SimpleSecurityService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,10 @@ public class SecurityAdapterConfig extends WebSecurityConfigurerAdapter implemen
     @NonNull
     private final SimpleSecurityService simpleSecurityService;
 
+
+    @NonNull
+    private final SimpleSecurityProperties properties;
+
     @Override
     public AuthenticationManager authenticationManagerBean() throws Exception {
         return super.authenticationManagerBean();
@@ -36,7 +41,7 @@ public class SecurityAdapterConfig extends WebSecurityConfigurerAdapter implemen
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
-        if (!this.simpleSecurityService.isUseCsrf()) {
+        if (!this.properties.isEnableCsrf()) {
             http = http.csrf().disable();
         }
         http = http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.NEVER).and();

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -43,12 +43,7 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>hsim.simple</groupId>
-            <artifactId>security</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
-            <scope>compile</scope>
-        </dependency>
+
     </dependencies>
 
     <build>

--- a/test/src/main/java/hsim/security/test/security/TestSecurityService.java
+++ b/test/src/main/java/hsim/security/test/security/TestSecurityService.java
@@ -26,14 +26,4 @@ public class TestSecurityService extends SimpleSecurityService {
                 .anyRequest().authenticated();
     }
 
-    @Override
-    public boolean isUseCsrf() {
-        return false;
-    }
-
-    @Override
-    public boolean isUseCors() {
-        return true;
-    }
-
 }

--- a/test/src/main/java/hsim/security/test/security/TestUserDetail.java
+++ b/test/src/main/java/hsim/security/test/security/TestUserDetail.java
@@ -7,29 +7,5 @@ import java.util.List;
 
 @Data
 public class TestUserDetail extends SimpleUserDetails {
-
     private Long id;
-    private String userName;
-    private String password;
-    private String role;
-
-    @Override
-    public String getPassword() {
-        return this.password;
-    }
-
-    @Override
-    public String getUsername() {
-        return this.userName;
-    }
-
-    @Override
-    protected String getRole() {
-        return this.role;
-    }
-
-    @Override
-    protected List<String> getRoles() {
-        return null;
-    }
 }

--- a/test/src/main/resources/application.properties
+++ b/test/src/main/resources/application.properties
@@ -1,2 +1,9 @@
 
 spring.h2.console.enabled=true
+
+simple.security.cors.enable=true
+simple.security.csrf.enable=true
+simple.security.cors.url=/**
+simple.security.cors.origins=*
+simple.security.cors.methods=*
+simple.security.cors.headers=*


### PR DESCRIPTION
6개 properties 추가 

#### simple.security.csrf.enable : csrf enable setting - default value true
#### simple.security.cors.enable : cors enable setting - default value false
#### simple.security.cors.url : cors mapping pattern - default value /**
#### simple.security.cors.origins : cors origins setting - default value *
#### simple.security.cors.methods : cors methods setting - default value *
#### simple.security.cors.headers : cors headers setting - default value *


README 수정

SimpleUserDetail 기본 field 추가 : username, password, role